### PR TITLE
Fixing a memory leak.

### DIFF
--- a/dotprod.c
+++ b/dotprod.c
@@ -53,7 +53,8 @@ void *initdp(signed short coeffs[],int len){
 void freedp(void *p){
   switch(Cpu_mode){
   case PORT:
-  default: ;
+  default:
+    return freedp_port(p);
 #ifdef __i386__
   case MMX:
   case SSE:


### PR DESCRIPTION
The freedp function does nothing in the PORT and default case.
This is a bug, and this commit fixes it.